### PR TITLE
Fixed missing attributes in generated code

### DIFF
--- a/SQL/Helpers.js
+++ b/SQL/Helpers.js
@@ -28,9 +28,6 @@ schema.hasMoreKnots = function() {
 schema.isFirstKnot = function() {
     return schema._iterator.knot == 1;
 };
-schema.resetKnots = function() {
-    schema._iterator.knot = 0;
-};
 
 var knot;
 while(knot = schema.nextKnot()) {

--- a/SQL/SQLServer/clr/Anchor.js
+++ b/SQL/SQLServer/clr/Anchor.js
@@ -3,15 +3,12 @@ while(anchor = schema.nextAnchor()) {
     while(attribute = anchor.nextAttribute()) {
         if(attribute.hasChecksum()) {
             thereAreHashes = true;
-            break;
         }
     }
 }
 while(knot = schema.nextKnot()) {
     if(knot.hasChecksum()) {
         thereAreHashes = true;
-        schema.resetKnots();
-        break;
     }
 }
 if(thereAreHashes) {


### PR DESCRIPTION
Removed some bad break-statements that had been left in the sisulet
creating the hash function, when checksum has been set on at least one
knot or attribute.