### PR TITLE
Fixed bug in CRT when using checksums

### DIFF
--- a/SQL/SQLServer/CreateSchemaTracking.js
+++ b/SQL/SQLServer/CreateSchemaTracking.js
@@ -818,6 +818,7 @@ begin
 
 	select @sql for xml path('');
 end
+GO
 -- Delete Everything with a Certain Metadata Id -----------------------------------------------------------------------
 -- deletes all rows from all tables that have the specified metadata id
 -----------------------------------------------------------------------------------------------------------------------
@@ -889,5 +890,6 @@ begin
 	end
 	exec(@sql);
 end
+GO
 ~*/
 }

--- a/SQL/SQLServer/crt/CreateAttributeRewinders.js
+++ b/SQL/SQLServer/crt/CreateAttributeRewinders.js
@@ -18,6 +18,7 @@ while (anchor = schema.nextAnchor()) {
     var knot, attribute;
     while (attribute = anchor.nextAttribute()) {
         if(attribute.isHistorized()) {
+            var returnType = attribute.isKnotted() ? attribute.knot.identity : (attribute.hasChecksum() ? 'varbinary(16)' : attribute.dataRange);
 /*~
 -- Attribute posit rewinder -------------------------------------------------------------------------------------------
 -- r$attribute.positName rewinding over changing time function
@@ -195,7 +196,7 @@ BEGIN
         @changingTimepoint $attribute.timeRange = '$schema.EOT',
         @positingTimepoint $schema.metadata.positingRange = '$schema.EOT'
     )
-    RETURNS $(attribute.isKnotted())? $attribute.knot.identity : $attribute.dataRange
+    RETURNS $returnType
     AS
     BEGIN RETURN (
         SELECT TOP 1
@@ -232,7 +233,7 @@ BEGIN
         @changingTimepoint $attribute.timeRange = '$schema.EOT',
         @positingTimepoint $schema.metadata.positingRange = '$schema.EOT'
     )
-    RETURNS $(attribute.isKnotted())? $attribute.knot.identity : $attribute.dataRange
+    RETURNS $returnType
     AS
     BEGIN RETURN (
         SELECT TOP 1


### PR DESCRIPTION
The return type of the functions finding previous and following values
was not set correctly when checksums were in use. This has now been
fixed.