### PR TITLE
Fixed knotted attribute delete bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,9 +137,9 @@
         var NodeType = {
             UNKNOWN:    0, '0': "Unknown",
             ANCHOR:     1, '1': "Anchor",
-            ATTRIBUTE:  2, '2': "Attribute",
-            TIE:        3, '3': "Tie",
-            KNOT:       4, '4': "Knot",
+            KNOT:       2, '2': "Knot",
+            ATTRIBUTE:  3, '3': "Attribute",
+            TIE:        4, '4': "Tie",
             EDGE:       5, '5': "Edge",
             PARTITION:  6, '6': "Partition",
             // "static variables" masses and charges, for example NodeType.mass[NodeType.ANCHOR];


### PR DESCRIPTION
When deleting a knotted attribute the knot would be left in the model,
since the deletes were being carried out in an incorrect order.