### PR TITLE
Fixed knot implode bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -1295,6 +1295,7 @@
                                                 break;
                                             }
                                         }
+                                        knotComponent = this.nodeToComponent(knot);
                                         knotEdgeComponent = this.nodeToComponent(knotEdge);
                                         knotEdgeComponent.hide();
                                         knotEdge.stop();
@@ -1305,6 +1306,7 @@
                                                 visibleEdges++;
                                         if(visibleEdges === 0) {
                                             knotEdgeComponent.hide();
+                                            knotComponent.hide();
                                             knot.stop();
                                             knot.visible = false;
                                         }


### PR DESCRIPTION
When doing “Implode all” some dangling knots were left in the diagram,
due to a missing .hide() call.