### PR TITLE
Fixed missing comma sign

### DIFF
--- a/SQL/SQLServer/crt/CreateAttributeAssembledViews.js
+++ b/SQL/SQLServer/crt/CreateAttributeAssembledViews.js
@@ -46,7 +46,7 @@ BEGIN
     EXEC('
     CREATE UNIQUE CLUSTERED INDEX [pk$attribute.name]
     ON [$attribute.capsule].[$attribute.name] (
-        $(schema.DECISIVENESS)? $attribute.assertionColumnName desc : $attribute.identityColumnName asc,
+        $(schema.DECISIVENESS)? $attribute.assertionColumnName desc, : $attribute.identityColumnName asc,
         $(schema.DECISIVENESS)? $attribute.anchorReferenceName asc,
         $(attribute.timeRange && schema.DECISIVENESS)? $attribute.changingColumnName desc,
         $attribute.positingColumnName desc,


### PR DESCRIPTION
A comma sign had gone astray, but has now found its way home. The result
was an error in the generated SQL that creates the assembled views, when
decisiveness is activated.