### PR TITLE
Fixed SVG glitch in debug mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -6106,8 +6106,8 @@
             SVGLayer.debug.style.stroke = '#fcc';
             SVGLayer.debug.style.strokeWidth = '7px';
             SVGLayer.debug.style.strokeLinecap = 'round';
-            SVGLayer.debugPartitions.style.fill = 'fff8f8';
-            SVGLayer.debugPartitions.style.stroke = 'f4ebeb';
+            SVGLayer.debugPartitions.style.fill = '#fff8f8';
+            SVGLayer.debugPartitions.style.stroke = '#f4ebeb';
             SVGLayer.debugPartitions.style.strokeWidth = LayoutEngine.fuzz;
             SVGLayer.names.setAttributeNS(null, 'class', 'label');
 


### PR DESCRIPTION
A couple of missing hash-marks in the color specifications made the
partitions draw in black in Chrome and Firefox (but not Safari). After
adding these the colors show up in all browsers when using debug mode.