### PR TITLE
Better trigger logic for default Metadata

### DIFF
--- a/SQL/SQLServer/crt/CreateAnchorTriggers.js
+++ b/SQL/SQLServer/crt/CreateAnchorTriggers.js
@@ -235,7 +235,17 @@ BEGIN
             $attribute.reliabilityColumnName
         )
         SELECT
-            $(schema.METADATA)? ISNULL(i.$attribute.metadataColumnName, i.$anchor.metadataColumnName),
+~*/
+                if(schema.METADATA) {
+/*~                        
+            CASE 
+                WHEN UPDATE($anchor.metadataColumnName) AND NOT UPDATE($attribute.metadataColumnName)
+                THEN i.$anchor.metadataColumnName
+                ELSE ISNULL(i.$attribute.metadataColumnName, i.$anchor.metadataColumnName)
+            END,
+~*/                 
+                }            
+/*~
             ISNULL(i.$attribute.anchorReferenceName, i.$anchor.identityColumnName),
             CASE 
                 WHEN UPDATE($attribute.valueColumnName) THEN i.$attribute.valueColumnName 
@@ -302,7 +312,17 @@ BEGIN
             $attribute.reliabilityColumnName
         )
         SELECT
-            $(schema.METADATA)? ISNULL(i.$attribute.metadataColumnName, i.$anchor.metadataColumnName),
+~*/
+                if(schema.METADATA) {
+/*~                        
+            CASE 
+                WHEN UPDATE($anchor.metadataColumnName) AND NOT UPDATE($attribute.metadataColumnName)
+                THEN i.$anchor.metadataColumnName
+                ELSE ISNULL(i.$attribute.metadataColumnName, i.$anchor.metadataColumnName)
+            END,
+~*/                 
+                }            
+/*~
             ISNULL(i.$attribute.anchorReferenceName, i.$anchor.identityColumnName),
             i.$attribute.valueColumnName,
 ~*/

--- a/SQL/SQLServer/uni/CreateAnchorTriggers.js
+++ b/SQL/SQLServer/uni/CreateAnchorTriggers.js
@@ -227,7 +227,17 @@ BEGIN
             $attribute.valueColumnName
         )
         SELECT
-            $(schema.METADATA)? ISNULL(i.$attribute.metadataColumnName, i.$anchor.metadataColumnName),
+~*/
+                    if(schema.METADATA) {
+/*~                        
+            CASE 
+                WHEN UPDATE($anchor.metadataColumnName) AND NOT UPDATE($attribute.metadataColumnName)
+                THEN i.$anchor.metadataColumnName
+                ELSE ISNULL(i.$attribute.metadataColumnName, i.$anchor.metadataColumnName)
+            END,
+~*/                 
+                    }            
+/*~
             ISNULL(i.$attribute.anchorReferenceName, i.$anchor.identityColumnName),
 ~*/
                     if(attribute.isHistorized()) {
@@ -274,7 +284,17 @@ BEGIN
             $attribute.valueColumnName
         )
         SELECT
-            $(schema.METADATA)? ISNULL(i.$attribute.metadataColumnName, i.$anchor.metadataColumnName),
+~*/
+                    if(schema.METADATA) {
+/*~                        
+            CASE 
+                WHEN UPDATE($anchor.metadataColumnName) AND NOT UPDATE($attribute.metadataColumnName)
+                THEN i.$anchor.metadataColumnName
+                ELSE ISNULL(i.$attribute.metadataColumnName, i.$anchor.metadataColumnName)
+            END,
+~*/                 
+                    }            
+/*~
             ISNULL(i.$attribute.anchorReferenceName, i.$anchor.identityColumnName),
             $(attribute.isEquivalent())? i.$attribute.equivalentColumnName,
 ~*/


### PR DESCRIPTION
Improved the handling of Metadata defaults in the update trigger, so
that if you only specify the anchor metadata any affected attributes
will inherit the same metadata id.