### PR TITLE
Added accidentally removed RETURNS clause

### DIFF
--- a/SQL/SQLServer/CreateSchemaTracking.js
+++ b/SQL/SQLServer/CreateSchemaTracking.js
@@ -233,6 +233,8 @@ GO
 CREATE FUNCTION [$schema.metadata.encapsulation].[_Evolution] (
     @timepoint AS $schema.metadata.chronon
 )
+RETURNS TABLE AS
+RETURN
 WITH constructs AS (
    SELECT
       temporalization,


### PR DESCRIPTION
When adding the new _Evolution function the RETURNS clause was
accidentally removed. Now it's back where it belongs.