### PR TITLE
Split statementType into posit and annex variables

### DIFF
--- a/SQL/SQLServer/crt/CreateAttributeTriggers.js
+++ b/SQL/SQLServer/crt/CreateAttributeTriggers.js
@@ -15,11 +15,14 @@
 var anchor, attribute;
 while (anchor = schema.nextAnchor()) {
     while(attribute = anchor.nextAttribute()) {
-        var statementTypes = "'N'";
-        if(attribute.isAssertive())
-            statementTypes += ",'D'";
-        if(attribute.isHistorized() && !attribute.isIdempotent())
-            statementTypes += ",'R'";
+        var annexStatementTypes = "'N'", positStatementTypes = "'N'";
+        if(attribute.isAssertive()) {
+            annexStatementTypes += ",'D'";
+        }
+        if(attribute.isHistorized() && !attribute.isIdempotent()) {
+            annexStatementTypes += ",'R'";
+            positStatementTypes += ",'R'";
+        }
         var changingParameter = attribute.isHistorized() ? 'v.' + attribute.changingColumnName : 'DEFAULT';
 /*~
 -- Insert trigger -----------------------------------------------------------------------------------------------------
@@ -172,7 +175,7 @@ BEGIN
         WHERE
             $attribute.versionColumnName = @currentVersion
         AND
-            $attribute.statementTypeColumnName in ($statementTypes);
+            $attribute.statementTypeColumnName in ($positStatementTypes);
 
         INSERT INTO [$attribute.capsule].[$attribute.annexName] (
             $(schema.METADATA)? $attribute.metadataColumnName,
@@ -200,7 +203,7 @@ BEGIN
         WHERE
             v.$attribute.versionColumnName = @currentVersion
         AND
-            $attribute.statementTypeColumnName in ('S',$statementTypes);
+            $attribute.statementTypeColumnName in ('S',$annexStatementTypes);
     END
 END
 GO

--- a/SQL/SQLServer/crt/CreateTieTriggers.js
+++ b/SQL/SQLServer/crt/CreateTieTriggers.js
@@ -141,11 +141,14 @@ BEGIN
         }
 /*~;~*/
         var changingParameter = tie.isHistorized() ? 'v.' + tie.changingColumnName : 'DEFAULT';
-        var statementTypes = "'N'";
-        if(tie.isAssertive())
-            statementTypes += ",'D'";
-        if(tie.isHistorized() && !tie.isIdempotent())
-            statementTypes += ",'R'";
+        var positStatementTypes = "'N'", annexStatementTypes = "'N'";
+        if(tie.isAssertive()) {
+            annexStatementTypes += ",'D'";
+        }
+        if(tie.isHistorized() && !tie.isIdempotent()) {
+            positStatementTypes += ",'R'";
+            annexStatementTypes += ",'R'";
+        }
 /*~
     SELECT
         @maxVersion = max($tie.versionColumnName),
@@ -339,7 +342,7 @@ BEGIN
         WHERE
             $tie.versionColumnName = @currentVersion
         AND
-            $tie.statementTypeColumnName in ($statementTypes);
+            $tie.statementTypeColumnName in ($positStatementTypes);
 
         INSERT INTO [$tie.capsule].[$tie.annexName] (
             $(schema.METADATA)? $tie.metadataColumnName,
@@ -372,7 +375,7 @@ BEGIN
         WHERE
             v.$tie.versionColumnName = @currentVersion
         AND
-            v.$tie.statementTypeColumnName in ('S',$statementTypes);
+            v.$tie.statementTypeColumnName in ('S',$annexStatementTypes);
     END
 END
 GO


### PR DESCRIPTION
In CRT the statementType variable had to split into two variables; one
for posits and one for annexes. The issue was that a new posit was
inserted when a reassertion was made, but since this posit already
existed a constraint was violated.