### PR TITLE
Reverted the performance tweak to the latest version in uni-temporal,…

### DIFF
--- a/SQL/SQLServer/uni/CreateAnchorPerspectives.js
+++ b/SQL/SQLServer/uni/CreateAnchorPerspectives.js
@@ -89,62 +89,33 @@ FROM
     [$anchor.capsule].[$anchor.name] [$anchor.mnemonic]
 ~*/
         while (attribute = anchor.nextAttribute()) {
-            if(attribute.isHistorized()) {
+            if(attribute.isEquivalent()) {
 /*~
-LEFT JOIN (
-    SELECT
-        $attribute.anchorReferenceName,
-        $(schema.METADATA)? MAX($attribute.metadataColumnName) AS $attribute.metadataColumnName,
-        MAX($attribute.changingColumnName) AS $attribute.changingColumnName,
-        $(attribute.isEquivalent())? MAX($attribute.equivalentColumnName) AS $attribute.equivalentColumnName,
-        MAX($attribute.valueColumnName) AS $attribute.valueColumnName
-    FROM (
-        SELECT
-            $attribute.anchorReferenceName,
-            $(schema.METADATA)? $attribute.metadataColumnName,
-            $attribute.changingColumnName,
-            $(attribute.isEquivalent())? $attribute.equivalentColumnName,
-            $attribute.valueColumnName,
-            ROW_NUMBER() OVER (PARTITION BY $attribute.anchorReferenceName ORDER BY $attribute.changingColumnName DESC) AS ReversedVersion
-        FROM
+LEFT JOIN
+    [$attribute.capsule].[e$attribute.name](0) [$attribute.mnemonic]
 ~*/
-                if(attribute.isEquivalent()) {
-/*~
-            [$attribute.capsule].[e$attribute.name](0)
-~*/
-                }
-                else {
-/*~
-            [$attribute.capsule].[$attribute.name]
-~*/
-                }
-/*~
-    ) a
-    WHERE
-        ReversedVersion = 1
-    GROUP BY
-        $attribute.anchorReferenceName
-) [$attribute.mnemonic]
-~*/
-            } // end of historized
+            }
             else {
 /*~
 LEFT JOIN
-~*/
-                if(attribute.isEquivalent()) {
-/*~
-    [$attribute.capsule].[e$attribute.name](0) [$attribute.mnemonic]
-~*/
-                }
-                else {
-/*~
     [$attribute.capsule].[$attribute.name] [$attribute.mnemonic]
 ~*/
-                }             
             }
 /*~
 ON
     [$attribute.mnemonic].$attribute.anchorReferenceName = [$anchor.mnemonic].$anchor.identityColumnName~*/
+            if(attribute.isHistorized()) {
+/*~
+AND
+    [$attribute.mnemonic].$attribute.changingColumnName = (
+        SELECT
+            max(sub.$attribute.changingColumnName)
+        FROM
+            $(attribute.isEquivalent())? [$attribute.capsule].[e$attribute.name](0) sub : [$attribute.capsule].[$attribute.name] sub
+        WHERE
+            sub.$attribute.anchorReferenceName = [$anchor.mnemonic].$anchor.identityColumnName
+   )~*/
+            }
             if(attribute.isKnotted()) {
                 knot = attribute.knot;
                 if(knot.isEquivalent()) {
@@ -207,61 +178,48 @@ FROM
 ~*/
         while (attribute = anchor.nextAttribute()) {
             if(attribute.isHistorized()) {
-/*~
-LEFT JOIN (
-    SELECT
-        $attribute.anchorReferenceName,
-        $(schema.METADATA)? MAX($attribute.metadataColumnName) AS $attribute.metadataColumnName,
-        MAX($attribute.changingColumnName) AS $attribute.changingColumnName,
-        $(attribute.isEquivalent())? MAX($attribute.equivalentColumnName) AS $attribute.equivalentColumnName,
-        MAX($attribute.valueColumnName) AS $attribute.valueColumnName
-    FROM (
-        SELECT
-            $attribute.anchorReferenceName,
-            $(schema.METADATA)? $attribute.metadataColumnName,
-            $attribute.changingColumnName,
-            $(attribute.isEquivalent())? $attribute.equivalentColumnName,
-            $attribute.valueColumnName,
-            ROW_NUMBER() OVER (PARTITION BY $attribute.anchorReferenceName ORDER BY $attribute.changingColumnName DESC) AS ReversedVersion
-        FROM
-~*/
                 if(attribute.isEquivalent()) {
 /*~
-            [$attribute.capsule].[r$attribute.name](0, @changingTimepoint)
+LEFT JOIN
+    [$attribute.capsule].[r$attribute.name](0, @changingTimepoint) [$attribute.mnemonic]
 ~*/
                 }
                 else {
 /*~
-            [$attribute.capsule].[r$attribute.name](@changingTimepoint)
+LEFT JOIN
+    [$attribute.capsule].[r$attribute.name](@changingTimepoint) [$attribute.mnemonic]
 ~*/
                 }
 /*~
-    ) a
-    WHERE
-        ReversedVersion = 1
-    GROUP BY
-        $attribute.anchorReferenceName
-) [$attribute.mnemonic]
-~*/
-            } // end of historized
+ON
+    [$attribute.mnemonic].$attribute.anchorReferenceName = [$anchor.mnemonic].$anchor.identityColumnName
+AND
+    [$attribute.mnemonic].$attribute.changingColumnName = (
+        SELECT
+            max(sub.$attribute.changingColumnName)
+        FROM
+            $(attribute.isEquivalent())? [$attribute.capsule].[r$attribute.name](0, @changingTimepoint) sub : [$attribute.capsule].[r$attribute.name](@changingTimepoint) sub
+        WHERE
+            sub.$attribute.anchorReferenceName = [$anchor.mnemonic].$anchor.identityColumnName
+   )~*/
+            }
             else {
-/*~
-LEFT JOIN
-~*/
                 if(attribute.isEquivalent()) {
 /*~
+LEFT JOIN
     [$attribute.capsule].[e$attribute.name](0) [$attribute.mnemonic]
 ~*/
                 }
                 else {
 /*~
+LEFT JOIN
     [$attribute.capsule].[$attribute.name] [$attribute.mnemonic]
 ~*/
-                }             
-            }
+                }
 /*~
 ON
     [$attribute.mnemonic].$attribute.anchorReferenceName = [$anchor.mnemonic].$anchor.identityColumnName~*/
+            }
             if(attribute.isKnotted()) {
                 knot = attribute.knot;
                 if(knot.isEquivalent()) {

--- a/about.html
+++ b/about.html
@@ -21,7 +21,7 @@
     </p>
     <h3>VERSION</h3>
     <p>
-        You are currently running version 0.99 <em>test</em> (release: Friday the 25th, January, 2019).
+        You are currently running version 0.99 <em>test</em> (release: Thursday the 7th, February, 2019).
     </p>
     <p>
         A change log describing the changes can be found here:


### PR DESCRIPTION
… since (while faster) this relied on statistics being completely up to date at all times, which is not realistically feasible.