### PR TITLE
Changed two more LEFT JOINS to WHERE NOT EXISTS

### DIFF
--- a/SQL/SQLServer/uni/CreateAttributeTriggers.js
+++ b/SQL/SQLServer/uni/CreateAttributeTriggers.js
@@ -72,18 +72,20 @@ BEGIN
         'P' -- new posit
     FROM
         inserted i
-    LEFT JOIN
-        [$attribute.capsule].[$attribute.name] p
-    ON
-        p.$attribute.anchorReferenceName = i.$attribute.anchorReferenceName
-    $(attribute.isEquivalent())? AND
-        $(attribute.isEquivalent())? p.$attribute.equivalentColumnName = i.$attribute.equivalentColumnName
-    $(attribute.isHistorized())? AND
-        $(attribute.isHistorized())? p.$attribute.changingColumnName = i.$attribute.changingColumnName
-    AND
-        $(attribute.hasChecksum())? p.$attribute.checksumColumnName = ${schema.metadata.encapsulation}$.MD5(cast(i.$attribute.valueColumnName as varbinary(max))) : p.$attribute.valueColumnName = i.$attribute.valueColumnName
-    WHERE -- the posit must be different (exclude the identical)
-        p.$attribute.anchorReferenceName is null;
+    WHERE NOT EXISTS (
+        SELECT 
+            x.$attribute.anchorReferenceName
+        FROM
+            [$attribute.capsule].[$attribute.name] x
+        WHERE
+            $(attribute.isEquivalent())? p.$attribute.equivalentColumnName = i.$attribute.equivalentColumnName
+        $(attribute.isEquivalent())? AND    
+            x.$attribute.anchorReferenceName = i.$attribute.anchorReferenceName
+        $(attribute.isHistorized())? AND
+            $(attribute.isHistorized())? x.$attribute.changingColumnName = i.$attribute.changingColumnName
+        AND
+            $(attribute.hasChecksum())? x.$attribute.checksumColumnName = i.$attribute.checksumColumnName : x.$attribute.valueColumnName = i.$attribute.valueColumnName
+    ); -- the posit must be different (exclude the identical)
 ~*/
         // fill table with entire history in these cases
         if(attribute.isIdempotent()) {

--- a/SQL/SQLServer/uni/CreateTieTriggers.js
+++ b/SQL/SQLServer/uni/CreateTieTriggers.js
@@ -85,35 +85,24 @@ BEGIN
 /*~
     FROM
         inserted i
-    LEFT JOIN
-        [$tie.capsule].[$tie.name] p
-    ON
+    WHERE NOT EXISTS (
+        SELECT 
+            42
+        FROM
+            [$tie.capsule].[$tie.name] x
+        WHERE 
 ~*/
-    while(role = tie.nextRole()) {
+        while(role = tie.nextRole()) {
 /*~
-        p.$role.columnName = i.$role.columnName
-    $(tie.hasMoreRoles())? AND
+            x.$role.columnName = i.$role.columnName
+        $(tie.hasMoreRoles())? AND
 ~*/
-    }
+        }
 /*~
-    $(tie.isHistorized())? AND
-        $(tie.isHistorized())? p.$tie.changingColumnName = i.$tie.changingColumnName
-    WHERE -- the posit must be different (exclude the identical)
+        $(tie.isHistorized())? AND
+            $(tie.isHistorized())? x.$tie.changingColumnName = i.$tie.changingColumnName
+    );
 ~*/
-    if(tie.hasMoreIdentifiers()) {
-        role = tie.nextIdentifier(); 
-/*~
-        p.$role.columnName is null;
-~*/
-        while(tie.nextIdentifier());
-    }
-    else {
-        role = tie.nextValue(); 
-/*~
-        p.$role.columnName is null;
-~*/
-        while(tie.nextValue());
-    }
     // fill table with entire history in these cases
     if(tie.isIdempotent()) {
 /*~

--- a/about.html
+++ b/about.html
@@ -18,7 +18,7 @@
     </p>
     <h3>VERSION</h3>
     <p>
-        You are currently running version 0.99.9.2 <em>test</em> (release: Tuesday the 12th, October, 2021).
+        You are currently running version 0.99.9.3 <em>test</em> (release: Thursday the 11th, November, 2021).
     </p>
     <p>
         A change log describing the releases can be found here:

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
         // <!--
         "use strict"; // be safe!
 
-        var VERSION = '0.99.9.2';
+        var VERSION = '0.99.9.3';
 
         // change to false in beta
         var RELEASE = false;


### PR DESCRIPTION
There were two more places where a LEFT JOIN could be changed to WHERE NOT EXISTS that were overlooked in the previous version. This should improve performance when you are inserting a comparatively small amount of data with respect to that already in your anchor and ties.