### PR TITLE
Added DISTINCT (multi-version inserts)

### DIFF
--- a/SQL/SQLServer/uni/CreateAnchorTriggers.js
+++ b/SQL/SQLServer/uni/CreateAnchorTriggers.js
@@ -147,7 +147,7 @@ BEGIN
         $(attribute.timeRange)? $attribute.changingColumnName,
         $attribute.valueColumnName
     )
-    SELECT
+    SELECT DISTINCT
         $(schema.METADATA)? i.$attribute.metadataColumnName,
         i.$attribute.anchorReferenceName,
         $(attribute.timeRange)? i.$attribute.changingColumnName,
@@ -231,7 +231,7 @@ BEGIN
             $(attribute.isHistorized())? $attribute.changingColumnName,
             $attribute.valueColumnName
         )
-        SELECT
+        SELECT DISTINCT
 ~*/
                 if(schema.METADATA) {
 /*~
@@ -328,7 +328,7 @@ BEGIN
             $(attribute.isHistorized())? $attribute.changingColumnName,
             $attribute.valueColumnName
         )
-        SELECT
+        SELECT DISTINCT
 ~*/
                 if(schema.METADATA) {
 /*~


### PR DESCRIPTION
Inserting multiple versions at once was not possible if there was at least one static attribute present in the insert.