### PR TITLE
Fix update of uninitialized static attribute

### DIFF
--- a/SQL/SQLServer/bi/CreateAnchorTriggers.js
+++ b/SQL/SQLServer/bi/CreateAnchorTriggers.js
@@ -204,8 +204,8 @@ BEGIN
 				knot = attribute.knot;
 /*~
     IF (
-        $(attribute.isHistorized())? UPDATE($attribute.valueColumnName) OR
-        $(attribute.isHistorized())? UPDATE($attribute.knotValueColumnName) OR
+        UPDATE($attribute.valueColumnName) OR
+        UPDATE($attribute.knotValueColumnName) OR
         UPDATE($attribute.reliabilityColumnName) OR
         UPDATE($schema.metadata.reliabilitySuffix)
     )
@@ -260,6 +260,8 @@ BEGIN
         ON
             $(knot.hasChecksum())? [k$knot.mnemonic].$knot.checksumColumnName = ${schema.metadata.encapsulation}$.MD5(cast(i.$attribute.knotValueColumnName as varbinary(max))) : [k$knot.mnemonic].$knot.valueColumnName = i.$attribute.knotValueColumnName
         WHERE
+            $(!attribute.isHistorized())? i.$attribute.identityColumnName is null
+        $(!attribute.isHistorized())? AND
             CASE
                 WHEN UPDATE($attribute.valueColumnName) THEN i.$attribute.valueColumnName
                 ELSE [k$knot.mnemonic].$knot.identityColumnName
@@ -319,7 +321,7 @@ BEGIN
 			else { // not knotted
 /*~
     IF (
-        $(attribute.isHistorized())? UPDATE($attribute.valueColumnName) OR
+        UPDATE($attribute.valueColumnName) OR
         UPDATE($attribute.reliabilityColumnName) OR
         UPDATE($schema.metadata.reliabilitySuffix)
     )
@@ -367,6 +369,8 @@ BEGIN
         FROM
             inserted i
         WHERE
+            $(!attribute.isHistorized())? i.$attribute.identityColumnName is null
+        $(!attribute.isHistorized())? AND
             i.$attribute.valueColumnName is not null
     END
 

--- a/about.html
+++ b/about.html
@@ -18,7 +18,7 @@
     </p>
     <h3>VERSION</h3>
     <p>
-        You are currently running version 0.99.9.7 <em>test</em> (release: Thursday the 17th, March, 2022).
+        You are currently running version 0.99.9.8 <em>test</em> (release: Friday the 27th, May, 2022).
     </p>
     <p>
         A change log describing the releases can be found here:

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
         // <!--
         "use strict"; // be safe!
 
-        var VERSION = '0.99.9.7';
+        var VERSION = '0.99.9.8';
 
         // change to false in beta
         var RELEASE = false;


### PR DESCRIPTION
Uninitialized static attributes could not be updated later, if a surrogate identity had already been created earlier.