### PR TITLE
Added schema references

### DIFF
--- a/about.html
+++ b/about.html
@@ -18,7 +18,7 @@
     </p>
     <h3>VERSION</h3>
     <p>
-        You are currently running version 0.99.12 <em>test</em> (release: Thursday the 25th, January 2024).
+        You are currently running version 0.99.13 <em>test</em> (release: Thursday the 11th, April 2024).
     </p>
     <p>
         A change log describing the releases can be found here:

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
         // <!--
         "use strict"; // be safe!
 
-        var VERSION = '0.99.12';
+        var VERSION = '0.99.13';
 
         // change to false in beta
         var RELEASE = false;


### PR DESCRIPTION
Schema references were missing from some of the utility functions and have now been added. A new function _GenerateDeleteScript has been added, from which you can quickly generate code that empties a database.