### PR TITLE
Add missing $ sign

### DIFF
--- a/SQL/SQLServer/CreateSchemaTracking.js
+++ b/SQL/SQLServer/CreateSchemaTracking.js
@@ -1462,7 +1462,7 @@ begin
 end
 go
 
-if OBJECT_ID('$schema.metadata.encapsulation._GenerateDeleteScript') is not null
+if OBJECT_ID('$schema.metadata.encapsulation$._GenerateDeleteScript') is not null
 drop proc [$schema.metadata.encapsulation]._GenerateDeleteScript;
 go
 


### PR DESCRIPTION
A dollar sign was missing, which resulted in an empty string being passed to OBJECT_ID and the _GenerateDeleteScript procedure was therefore never dropped.