### PR TITLE
Fix erroneous reference

### DIFF
--- a/SQL/SQLServer/uni/AddAttributeRestatementConstraints.js
+++ b/SQL/SQLServer/uni/AddAttributeRestatementConstraints.js
@@ -112,7 +112,7 @@ BEGIN
     $(attribute.isEquivalent())? AND    
         p.$attribute.anchorReferenceName = i.$attribute.anchorReferenceName
     WHERE NOT EXISTS (
-        SELECT 
+        SELECT TOP 1
             x.$attribute.anchorReferenceName
         FROM
             @$attribute.name x

--- a/SQL/SQLServer/uni/AddTieRestatementConstraints.js
+++ b/SQL/SQLServer/uni/AddTieRestatementConstraints.js
@@ -162,7 +162,7 @@ BEGIN
         }
 /*~
     WHERE NOT EXISTS (
-        SELECT 
+        SELECT TOP 1
             42
         FROM
             @inserted x
@@ -173,7 +173,7 @@ BEGIN
             while(role = tie.nextIdentifier()) {
 /*~
         AND
-            p.$role.columnName = i.$role.columnName
+            x.$role.columnName = i.$role.columnName
 ~*/
             }
         }
@@ -181,7 +181,7 @@ BEGIN
             while(role = tie.nextValue()) {
 /*~
         AND
-            p.$role.columnName = i.$role.columnName
+            x.$role.columnName = i.$role.columnName
 ~*/
             }
         }

--- a/SQL/SQLServer/uni/CreateAttributeTriggers.js
+++ b/SQL/SQLServer/uni/CreateAttributeTriggers.js
@@ -73,12 +73,12 @@ BEGIN
     FROM
         inserted i
     WHERE NOT EXISTS (
-        SELECT 
+        SELECT TOP 1
             x.$attribute.anchorReferenceName
         FROM
             [$attribute.capsule].[$attribute.name] x
         WHERE
-            $(attribute.isEquivalent())? p.$attribute.equivalentColumnName = i.$attribute.equivalentColumnName
+            $(attribute.isEquivalent())? x.$attribute.equivalentColumnName = i.$attribute.equivalentColumnName
         $(attribute.isEquivalent())? AND    
             x.$attribute.anchorReferenceName = i.$attribute.anchorReferenceName
         $(attribute.isHistorized())? AND
@@ -230,12 +230,12 @@ BEGIN
     FROM
         inserted i
     WHERE NOT EXISTS (
-        SELECT 
+        SELECT TOP 1
             x.$attribute.anchorReferenceName
         FROM
             [$attribute.capsule].[$attribute.name] x
         WHERE
-            $(attribute.isEquivalent())? p.$attribute.equivalentColumnName = i.$attribute.equivalentColumnName
+            $(attribute.isEquivalent())? x.$attribute.equivalentColumnName = i.$attribute.equivalentColumnName
         $(attribute.isEquivalent())? AND    
             x.$attribute.anchorReferenceName = i.$attribute.anchorReferenceName
         AND

--- a/SQL/SQLServer/uni/CreateTieTriggers.js
+++ b/SQL/SQLServer/uni/CreateTieTriggers.js
@@ -86,7 +86,7 @@ BEGIN
     FROM
         inserted i
     WHERE NOT EXISTS (
-        SELECT 
+        SELECT TOP 1
             42
         FROM
             [$tie.capsule].[$tie.name] x
@@ -326,7 +326,7 @@ BEGIN
     FROM
         inserted i
     WHERE NOT EXISTS (
-        SELECT 
+        SELECT TOP 1
             42
         FROM
             [$tie.capsule].[$tie.name] x


### PR DESCRIPTION
In several WHERE NOT EXISTS statement the wrong table alias was used, resulting in a query with an erroneous join condition and severely degrading performance over time.